### PR TITLE
Handle error without interrupting gulp watch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,8 @@ var browserify = require('browserify'),
     ga = require('gulp-ga'),
     jest = require('gulp-jest'),
     source = require("vinyl-source-stream"),
-    reactify = require('reactify');
+    reactify = require('reactify'),
+    notify = require('gulp-notify');
 
 
 var paths = {
@@ -21,6 +22,10 @@ gulp.task('browserify-reactify', function() {
     b.add('./src/main.js');
 
     return b.bundle()
+        .on("error", notify.onError({
+            message: "Error: <%= error.message %>",
+            title: "Error during browserify"
+          }))
         .pipe(source('app.js'))
         .pipe(gulp.dest('./build/js'));
 });

--- a/package.json
+++ b/package.json
@@ -12,18 +12,19 @@
     "test": "gulp test"
   },
   "devDependencies": {
-    "react": "^0.12.0",
-    "semver": "^4.1.0",
-    "gulp-browserify": "^0.5.0",
-    "gulp": "^3.8.9",
-    "vinyl-source-stream": "^1.0.0",
-    "reactify": "^0.15.2",
     "browserify": "^6.2.0",
-    "gulp-less": "^1.3.6",
+    "gulp": "^3.8.9",
     "gulp-autoprefixer": "^1.0.1",
+    "gulp-browserify": "^0.5.0",
     "gulp-ga": "0.0.1",
-    "react-tools": "^0.12.0",
+    "gulp-jest": "^0.2.2",
+    "gulp-less": "^1.3.6",
+    "gulp-notify": "^2.0.1",
     "jest-cli": "^0.1.18",
-    "gulp-jest": "^0.2.2"
+    "react": "^0.12.0",
+    "react-tools": "^0.12.0",
+    "reactify": "^0.15.2",
+    "semver": "^4.1.0",
+    "vinyl-source-stream": "^1.0.0"
   }
 }


### PR DESCRIPTION
- JS/JSX syntax error caused gulp to crash during a watch. Fix that by adding on("error",...) in browserify bundle phase
- Add gulp-notify to get system notification on error
