### PR TITLE
Fix a couple of typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Check it online here: [http://jubianchi.github.io/semver-check](http://jubianchi
 
 > The bigger your system grows and the more packages you integrate into your software, the more likely you are to find yourself, one day, in this pit of despair.
 
-More and more projects try to follow [Semantic Versionning](http://semver.org/) to reduce package versionning nightmare and every dependency manager implement its own semantic versionner.
+More and more projects try to follow [Semantic Versioning](http://semver.org/) to reduce package versioning nightmare and every dependency manager implement its own semantic versioner.
 Composer and NPM for example don't handle version constraints the same way. It's hard sometimes to be sure how some library version will behave against some constraint.
 
 This tiny webapp checks if a given version satisfies another given constraint in the NPM world.

--- a/src/index.html
+++ b/src/index.html
@@ -25,8 +25,8 @@
             </blockquote>
 
             <p>
-                More and more projects try to follow Semantic Versionning to reduce package versionning nightmare and
-                every dependency manager implement its own semantic versionner. <a href="https://getcomposer.org/">Composer</a> and <a href="https://www.npmjs.org/">NPM</a> for example don't
+                More and more projects try to follow Semantic Versioning to reduce package versioning nightmare and
+                every dependency manager implements its own semantic versioner. <a href="https://getcomposer.org/">Composer</a> and <a href="https://www.npmjs.org/">NPM</a> for example don't
                 handle version constraints the same way. It's hard sometimes to be sure how some library version will
                 behave against some constraint.
             </p>
@@ -41,7 +41,7 @@
             <h2>Semver constraint implementations</h2>
 
             <p>
-                Semantic Versionning stands as a standard versionning scheme but it does not
+                Semantic Versioning stands as a standard versioning scheme but it does not
                 (<a href="https://github.com/mojombo/semver/issues/113">yet</a>) cover dependency management and how to
                 express constraint.
             </p>
@@ -89,7 +89,7 @@
 
             <p>
                 Using such constraints, you will allow your dependency manager to pull patch releases letting you get
-                bug fixes. If the library you are depending on strictly implements Semantic Versionning you should be able to
+                bug fixes. If the library you are depending on strictly implements Semantic Versioning you should be able to
                 make your constraint even more flexible by allowing your dependency manager to also pull new features:
             </p>
 
@@ -109,7 +109,7 @@
             <p>
                 Why? Because with them you are only giving a lower bound to your dependency's version, which means
                 every version greater than the one you chose, be it a patch, minor or major release. If we read
-                Semantic Versionning carefully:
+                Semantic Versioning carefully:
             </p>
 
             <blockquote>


### PR DESCRIPTION
Hi! thanks for this app - it's my go-to for checking semver ranges.

This PR has a tiny fix for a few typos, where there was a double "n" in words like "versioning". Not important I know, but I thought i'd raise it in case you find it useful.

Thanks again :clap: 