### PR TITLE
Fix match on null with ~ and ^

### DIFF
--- a/__tests__/SemverConstraint-test.js
+++ b/__tests__/SemverConstraint-test.js
@@ -13,6 +13,8 @@ describe('SemverConstraint', function() {
     });
 
     it('should compute constraint parts', function() {
+        expect(new SemverConstraint('1').parts()).toEqual(['1']);
+        expect(new SemverConstraint('1.0').parts()).toEqual(['1', '0']);
         expect(new SemverConstraint('1.0.0').parts()).toEqual(['1', '0', '0']);
         expect(new SemverConstraint('^1.0.0').parts()).toEqual(['1', '0', '0']);
         expect(new SemverConstraint('~1.0.0').parts()).toEqual(['1', '0', '0']);
@@ -22,6 +24,8 @@ describe('SemverConstraint', function() {
     });
 
     it('should compute cleaned version', function() {
+        expect(new SemverConstraint('1').cleaned()).toEqual('1');
+        expect(new SemverConstraint('1.0').cleaned()).toEqual('1.0');
         expect(new SemverConstraint('1.0.0').cleaned()).toEqual('1.0.0');
         expect(new SemverConstraint('^1.0.*').cleaned()).toEqual('1.0');
         expect(new SemverConstraint('~  1.0.0').cleaned()).toEqual('1.0.0');
@@ -41,6 +45,8 @@ describe('SemverConstraint', function() {
     });
 
     it('should cast to string', function() {
+        expect(new SemverConstraint('1').toString()).toEqual('1');
+        expect(new SemverConstraint('1.0').toString()).toEqual('1.0');
         expect(new SemverConstraint('1.0.0').toString()).toEqual('1.0.0');
         expect(new SemverConstraint('^1.x').toString()).toEqual('^1.x');
         expect(new SemverConstraint('~0.2.3').toString()).toEqual('~0.2.3');
@@ -114,11 +120,14 @@ describe('SemverConstraint', function() {
             '1.2': '<1.3.0',
             '~1.2.3': '<1.3.0',
             '~1.2': '<1.3.0',
+            '~1.0': '<1.1.0',
             '~1': '<2.0.0',
             '~0.2.3': '<0.3.0',
             '~0.2': '<0.3.0',
             '~0': '<1.0.0',
             '~1.2.3-beta.2': '<1.3.0',
+            '^1': '<2.0.0',
+            '^1.0': '<2.0.0',
             '^1.2.3': '<2.0.0',
             '^0.2.3': '<0.3.0',
             '^0.0.3': '<0.0.4',

--- a/src/libs/semver-constraint.js
+++ b/src/libs/semver-constraint.js
@@ -177,7 +177,7 @@ SemverConstraint.prototype = {
                 if (this.parts().length === 1) {
                     upper = semver.inc(padVersion(this.cleaned(), '0'), 'major');
                 } else {
-                    if (this.parts()[1] === "0" && this.parts()[2].match(/^0-/)) {
+                    if (this.parts()[1] === "0" && this.parts().length > 2 && this.parts()[2].match(/^0-/)) {
                         upper = semver.inc(padVersion(this.lower().cleaned(false), '0'), 'minor');
                     } else {
                         upper = semver.inc(padVersion(this.cleaned(), '0'), 'minor');
@@ -207,7 +207,7 @@ SemverConstraint.prototype = {
                         upper = semver.inc(padVersion(this.lower().cleaned(), '0'), 'major');
                     }
                 } else {
-                    if (this.parts()[1] === "0" && this.parts()[2].match(/^0-/)) {
+                    if (this.parts()[1] === "0" && this.parts().length > 2 && this.parts()[2].match(/^0-/)) {
                         upper = semver.inc(padVersion(this.lower().cleaned(false), '0'), 'major');
                     } else {
                         upper = semver.inc(padVersion(this.lower().cleaned(), '0'), 'major');


### PR DESCRIPTION
This is an attempt to fix https://github.com/jubianchi/semver-check/issues/33

The code which works out the upper bound under certain circumstances makes the assumption the version number has three parts. This means that something like `^1.0` causes an error but `^1.0.0` is fine.

I don't fully understand the intent behind the bit of code that breaks, but I've added a change which makes this section more defensive. I've also added test cases for it.