### PR TITLE
Fix npm capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Check it online here: [http://jubianchi.github.io/semver-check](http://jubianchi
 > The bigger your system grows and the more packages you integrate into your software, the more likely you are to find yourself, one day, in this pit of despair.
 
 More and more projects try to follow [Semantic Versioning](http://semver.org/) to reduce package versioning nightmare and every dependency manager implement its own semantic versioner.
-Composer and NPM for example don't handle version constraints the same way. It's hard sometimes to be sure how some library version will behave against some constraint.
+Composer and npm for example don't handle version constraints the same way. It's hard sometimes to be sure how some library version will behave against some constraint.
 
-This tiny webapp checks if a given version satisfies another given constraint in the NPM world.
+This tiny webapp checks if a given version satisfies another given constraint in the npm world.
 
 ## Run it!
 

--- a/src/components/Implementations.js
+++ b/src/components/Implementations.js
@@ -15,12 +15,12 @@ const Implementations = props => (
             <p>
                 Without any formal specification about constraint, dependency managers sometimes handle or express them
                 differently. For example, the tilde-range constraint (<code>~x.y</code>) does not work the same way in{' '}
-                <a href="https://www.npmjs.org/">NPM</a> and <a href="https://getcomposer.org">Composer</a>.
+                <a href="https://www.npmjs.org/">npm</a> and <a href="https://getcomposer.org">Composer</a>.
             </p>
 
             <ul>
                 <li>
-                    See how <a href="https://www.npmjs.org/">NPM</a> handles constraints:{' '}
+                    See how <a href="https://www.npmjs.org/">npm</a> handles constraints:{' '}
                     <a href="https://github.com/npm/node-semver">npm/node-semver</a>
                 </li>
                 <li>

--- a/src/components/Why.js
+++ b/src/components/Why.js
@@ -19,7 +19,7 @@ const Why = props => (
             <p>
                 More and more projects try to follow Semantic Versioning to reduce package versioning nightmare and
                 every dependency manager implements its own semantic versioner.{' '}
-                <a href="https://getcomposer.org/">Composer</a> and <a href="https://www.npmjs.org/">NPM</a> for example
+                <a href="https://getcomposer.org/">Composer</a> and <a href="https://www.npmjs.org/">npm</a> for example
                 don't handle version constraints the same way. It's hard sometimes to be sure how some library version
                 will behave against some constraint.
             </p>


### PR DESCRIPTION
Just a minor capitalization fix: `NPM` -> `npm`

npm should never be capitalized:
https://github.com/npm/cli#is-it-npm-or-npm-or-npm